### PR TITLE
Fix crashes on RX init

### DIFF
--- a/uart_terminal_uart.c
+++ b/uart_terminal_uart.c
@@ -38,8 +38,6 @@ void uart_terminal_uart_on_irq_cb(UartIrqEvent ev, uint8_t data, void* context) 
 static int32_t uart_worker(void* context) {
     UART_TerminalUart* uart = (void*)context;
 
-    uart->rx_stream = furi_stream_buffer_alloc(RX_BUF_SIZE, 1);
-
     while(1) {
         uint32_t events =
             furi_thread_flags_wait(WORKER_ALL_RX_EVENTS, FuriFlagWaitAny, FuriWaitForever);
@@ -64,6 +62,16 @@ void uart_terminal_uart_tx(uint8_t* data, size_t len) {
 
 UART_TerminalUart* uart_terminal_uart_init(UART_TerminalApp* app) {
     UART_TerminalUart* uart = malloc(sizeof(UART_TerminalUart));
+    uart->app = app;
+    // Init all rx stream and thread early to avoid crashes
+    uart->rx_stream = furi_stream_buffer_alloc(RX_BUF_SIZE, 1);
+    uart->rx_thread = furi_thread_alloc();
+    furi_thread_set_name(uart->rx_thread, "UART_TerminalUartRxThread");
+    furi_thread_set_stack_size(uart->rx_thread, 1024);
+    furi_thread_set_context(uart->rx_thread, uart);
+    furi_thread_set_callback(uart->rx_thread, uart_worker);
+
+    furi_thread_start(uart->rx_thread);
 
     furi_hal_console_disable();
     if(app->BAUDRATE == 0) {
@@ -72,14 +80,6 @@ UART_TerminalUart* uart_terminal_uart_init(UART_TerminalApp* app) {
     furi_hal_uart_set_br(UART_CH, app->BAUDRATE);
     furi_hal_uart_set_irq_cb(UART_CH, uart_terminal_uart_on_irq_cb, uart);
 
-    uart->app = app;
-    uart->rx_thread = furi_thread_alloc();
-    furi_thread_set_name(uart->rx_thread, "UART_TerminalUartRxThread");
-    furi_thread_set_stack_size(uart->rx_thread, 1024);
-    furi_thread_set_context(uart->rx_thread, uart);
-    furi_thread_set_callback(uart->rx_thread, uart_worker);
-
-    furi_thread_start(uart->rx_thread);
     return uart;
 }
 


### PR DESCRIPTION
Fixes crashes on RX init stage when we have something connected to RX and its sending data
```
1. To replicate crash you need to connect something that sends data into RX pin, like GPS module
2. Launch and close plugin couple times
```

This PR fixes this issue, and fixes #11 issue which is related to this